### PR TITLE
statically link libzmq

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -32,7 +32,7 @@
             }
           },
         }, {
-          'libraries': ['-lzmq'],
+          'libraries': [ '<!@(pkg-config libzmq --variable=libdir)/libzmq.a' ],
           'cflags!': ['-fno-exceptions'],
           'cflags_cc!': ['-fno-exceptions'],
         }],


### PR DESCRIPTION
instead of dll, which relies on users having the same libzmq in the same place, defeating some of the point.

Right now, this requires pkg-config to locate libzmq.a. Finding libzmq can be done with some manual checking as well, but if the goal is prebuilt binaries, requiring pkg-config should be okay.