### PR TITLE
use tweetnacl for bundled nacl instead of libsodium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ os:
 osx_image: xcode7.2
 
 env:
- - ZMQ="4.1.3" SODIUM="1.0.5" NODE_VERSION="5"
- - ZMQ="4.1.3" SODIUM="1.0.5" NODE_VERSION="4"
+ # libzmq-4.1.5 prerelease for tweetnacl build fixes
+ - ZMQ="b539733cee0f47f9bf1a70dc7cb7ff20410d3380" NODE_VERSION="5"
+ - ZMQ="b539733cee0f47f9bf1a70dc7cb7ff20410d3380" NODE_VERSION="4"
 
 before_install:
  - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.30.2/install.sh | bash
@@ -27,34 +28,23 @@ before_install:
  - nvm use $NODE_VERSION
  - node --version
  - npm --version
- - export CXX=g++-4.8
- - export CC=gcc-4.8
- - mkdir ldlocal
- - export LDHACK=`pwd`/ldlocal
- - export LDFLAGS=-L$LDHACK/lib
- - export CFLAGS=-I$LDHACK/include
- - export LD_RUN_PATH=$LDHACK/lib
- - export LD_LIBRARY_PATH=$LDHACK/lib
- - export PKG_CONFIG_PATH=$LDHACK/lib/pkgconfig
+ - test "$(uname)" = "Darwin"  || export CXX=g++-4.8 CC=gcc-4.8
+ - gcc --version
+ - mkdir zmq
+ - export ZMQ_PREFIX=`pwd`/zmq
+ - export CFLAGS=-fPIC
+ - export CXXFLAGS=-fPIC
+ - export PKG_CONFIG_PATH=$ZMQ_PREFIX/lib/pkgconfig
  - echo $PKG_CONFIG_PATH
- - wget http://download.zeromq.org/zeromq-$ZMQ.tar.gz
+ - wget https://github.com/zeromq/zeromq4-1/archive/$ZMQ.tar.gz -O zeromq-$ZMQ.tar.gz
  - tar xzvf zeromq-$ZMQ.tar.gz
- - '[ -z "$SODIUM" ] || wget https://download.libsodium.org/libsodium/releases/libsodium-$SODIUM.tar.gz'
- - '[ -z "$SODIUM" ] || tar xzvf libsodium-$SODIUM.tar.gz'
- - '[ -z "$SODIUM" ] || cd libsodium-$SODIUM'
- - '[ -z "$SODIUM" ] || ./autogen.sh'
- - '[ -z "$SODIUM" ] || ./configure --prefix=$LDHACK'
- - '[ -z "$SODIUM" ] || make'
- - '[ -z "$SODIUM" ] || make install'
- - '[ -z "$SODIUM" ] || cd ..'
- - '[ -z "$SODIUM" ] || export LIBS=-lsodium && export sodium_CFLAGS=$CFLAGS && export sodium_LIBS=$LDFLAGS'
- - cd zeromq-$ZMQ
+ - cd zeromq4-1-$ZMQ
  - ./autogen.sh
- - if [[ -z "$SODIUM" ]]; then ./configure --prefix=$LDHACK; else ./configure --prefix=$LDHACK --with-libsodium=$LDHACK; fi
- - make
+ - ./configure --prefix=$ZMQ_PREFIX --with-tweetnacl --with-relaxed --enable-static --disable-shared
+ - V=1 make -j
  - make install
  - cd ..
 
-install: env LD_LIBRARY_PATH=$LDHACK/lib LD_RUN_PATH=$LDHACK/lib PKG_CONFIG_PATH=$LDHACK/lib/pkgconfig LDFLAGS=-L$LDHACK/lib CFLAGS=-I$LDHACK/lib/include npm install
+install: env PKG_CONFIG_PATH=$ZMQ_PREFIX/lib/pkgconfig npm install
 
 script: travis_retry npm test

--- a/binding.gyp
+++ b/binding.gyp
@@ -47,7 +47,6 @@
             '/usr/local/include',
           ],
           'libraries': [
-            '<!@(pkg-config libzmq --libs)',
             '-L/opt/local/lib',
             '-L/usr/local/lib',
           ]
@@ -56,18 +55,11 @@
           'include_dirs': [
             '<!@(pkg-config libzmq --cflags-only-I | sed s/-I//g)',
             '/usr/local/include',
-          ],
-          'libraries': [
-            '<!@(pkg-config libzmq --libs)',
-            '-L/usr/local/lib',
           ]
         }],
         ['OS=="linux"', {
           'cflags': [
             '<!(pkg-config libzmq --cflags 2>/dev/null || echo "")',
-          ],
-          'libraries': [
-            '<!(pkg-config libzmq --libs 2>/dev/null || echo "")',
           ],
         }],
       ]

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,27 @@
+// cleanup utils for sockets
+var sockets = [];
+
+exports.cleanup = function (done) {
+  while (sockets.length) {
+    sockets.pop().close();
+  }
+  // give underlying sockets some time to close
+  // this shouldn't be necessary on *ix, but it seems to be
+  setTimeout(function () {
+    done();
+  }, 500);
+};
+
+exports.push_sockets = function () {
+  sockets.push.apply(sockets, arguments);
+};
+
+exports.done_countdown = function (done, counter) {
+  // add a done-countdown, so multiple async events can be awaited before triggering done
+  return function () {
+    counter -= 1;
+    if (counter === 0) {
+      done();
+    }
+  }
+};

--- a/test/zmq_proxy.xrep-xreq.js
+++ b/test/zmq_proxy.xrep-xreq.js
@@ -9,8 +9,11 @@ var addr = 'tcp://127.0.0.1'
 
 //since its for libzmq2, we target versions < 3.0.0
 var version = semver.lte(zmq.version, '3.0.0');
+var testutil = require('./util');
 
 describe('proxy.xrep-xreq', function() {
+  afterEach(testutil.cleanup);
+  
   it('should proxy req-rep connected to xrep-xreq', function (done) {
     if (!version) {
       done();
@@ -28,14 +31,11 @@ describe('proxy.xrep-xreq', function() {
 
     req.connect(frontendAddr);
     rep.connect(backendAddr);
+    testutil.push_sockets(frontend, backend, req, rep);
 
     req.on('message',function(msg){
       msg.should.be.an.instanceof(Buffer);
       msg.toString().should.equal('foo bar');
-      frontend.close();
-      backend.close();
-      req.close();
-      rep.close();
       done();
     });
 


### PR DESCRIPTION
avoids need to bundle an extra library. This means zmq-prebuilt should always have curve support and no DLL dependencies.

Bummer: build settings for tweetnacl have never worked (should be fixed in libzmq-4.1.5), so this uses a prerelease of 4.1.5 from GitHub.

In order to get things passing on the OS X travis bot, I had to do some cleanup in a few tests that had loads of race conditions.