### PR TITLE
make libzmq build stage a script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ binding.Makefile
 binding.target.gyp.mk
 gyp-mac-tool
 out/
+zmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,20 +30,7 @@ before_install:
  - npm --version
  - test "$(uname)" = "Darwin"  || export CXX=g++-4.8 CC=gcc-4.8
  - gcc --version
- - mkdir zmq
- - export ZMQ_PREFIX=`pwd`/zmq
- - export CFLAGS=-fPIC
- - export CXXFLAGS=-fPIC
- - export PKG_CONFIG_PATH=$ZMQ_PREFIX/lib/pkgconfig
- - echo $PKG_CONFIG_PATH
- - wget https://github.com/zeromq/zeromq4-1/archive/$ZMQ.tar.gz -O zeromq-$ZMQ.tar.gz
- - tar xzvf zeromq-$ZMQ.tar.gz
- - cd zeromq4-1-$ZMQ
- - ./autogen.sh
- - ./configure --prefix=$ZMQ_PREFIX --with-tweetnacl --with-relaxed --enable-static --disable-shared
- - V=1 make -j
- - make install
- - cd ..
+ - sh build_libzmq.sh
 
 install: env PKG_CONFIG_PATH=$ZMQ_PREFIX/lib/pkgconfig npm install
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -32,7 +32,8 @@
             }
           },
         }, {
-          'libraries': [ '<!@(pkg-config libzmq --variable=libdir)/libzmq.a' ],
+          'libraries': [ '<(PRODUCT_DIR)/../../zmq/lib/libzmq.a' ],
+          'include_dirs': [ '<(PRODUCT_DIR)/../../zmq/include' ],
           'cflags!': ['-fno-exceptions'],
           'cflags_cc!': ['-fno-exceptions'],
         }],
@@ -40,27 +41,10 @@
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
           },
-          # add macports include & lib dirs, homebrew include & lib dirs
-          'include_dirs': [
-            '<!@(pkg-config libzmq --cflags-only-I | sed s/-I//g)',
-            '/opt/local/include',
-            '/usr/local/include',
-          ],
-          'libraries': [
-            '-L/opt/local/lib',
-            '-L/usr/local/lib',
-          ]
         }],
         ['OS=="openbsd" or OS=="freebsd"', {
-          'include_dirs': [
-            '<!@(pkg-config libzmq --cflags-only-I | sed s/-I//g)',
-            '/usr/local/include',
-          ]
         }],
         ['OS=="linux"', {
-          'cflags': [
-            '<!(pkg-config libzmq --cflags 2>/dev/null || echo "")',
-          ],
         }],
       ]
     }

--- a/build_libzmq.sh
+++ b/build_libzmq.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+test -d zmq || mkdir zmq
+
+export ZMQ=b539733cee0f47f9bf1a70dc7cb7ff20410d3380 # zeromq-4.1.5 prerelease for tweetnacl support
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+export ZMQ_PREFIX="$(dirname $(realpath $0))/zmq"
+export ZMQ_SRC_DIR=zeromq4-1-$ZMQ
+cd $ZMQ_PREFIX
+
+export CFLAGS=-fPIC
+export CXXFLAGS=-fPIC
+export PKG_CONFIG_PATH=$ZMQ_PREFIX/lib/pkgconfig
+
+test -f zeromq-$ZMQ.tar.gz || wget https://github.com/zeromq/zeromq4-1/archive/$ZMQ.tar.gz -O zeromq-$ZMQ.tar.gz
+test -d $ZMQ_SRC_DIR || tar xzf zeromq-$ZMQ.tar.gz
+cd $ZMQ_SRC_DIR
+
+test -f configure || ./autogen.sh
+./configure --prefix=$ZMQ_PREFIX --with-tweetnacl --with-relaxed --enable-static --disable-shared
+V=1 make -j
+make install


### PR DESCRIPTION
so it's reusable outside Travis

next step: run build_libzmq.sh as prepublish (or preinstall or whatever stage is the right one) prior to build on non-Windows, so it's always run automatically. I just don't know how to do the if-not-Windows part. I'll let someone with more js build experience figure that out.