### PR TITLE
git ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ binding.target.gyp.mk
 gyp-mac-tool
 out/
 zmq
+
+npm-debug.log
+prebuilds


### PR DESCRIPTION
This works wonderfully!

Ran:

```
./build_libzmq.sh
prebuild
```

and it made the right prebuild! :tada:

Then I noticed some artifacts here for gitignoring.