### PR TITLE
Avoid using preinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "node": ">=0.8"
   },
   "scripts": {
-    "preinstall": "node build.js",
-    "install": "prebuild --install",
+    "install": "node build.js && prebuild --install",
     "test": "mocha --expose-gc --slow 2000 --timeout 600000"
   },
   "keywords": [


### PR DESCRIPTION
A temporary fix for the fact that the preinstall script in npm is not guaranteed to run before install every time. This manifests itself up in the main nteract app when we try to use the enchannel-zmq-backend that relies on zmq-prebuilt.