### PR TITLE
install must rely only on prebuild

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const exec = require('child_process').exec;
 
 if (process.platform === 'linux' || process.platform === 'darwin') {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=0.8"
   },
   "scripts": {
-    "install": "node build.js && prebuild --install",
+    "install": "prebuild --install",
     "test": "mocha --expose-gc --slow 2000 --timeout 600000"
   },
   "keywords": [


### PR DESCRIPTION
dev installs need to run the build_zmq.sh script before `npm install`

users will rely on the prebuilt binaries we upload