### PR TITLE
[DO NOT MERGE] re-enable x86 builds on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
 platform:
   - x64
-  # - x86 # x86 builds aren't working for now
+  - x86
 
 configuration:
   - release


### PR DESCRIPTION
This won't work, but submitting to trigger the failure on appveyor for reference.