### PR TITLE
Add in-publish to execute prepublish correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "url": "http://github.com/nteract/zmq-prebuilt.git"
   },
   "dependencies": {
+    "bindings": "~1.2.1",
+    "in-publish": "^2.0.0",
     "nan": "~2.4.0",
-    "prebuild": "^2.9.0",
-    "bindings": "~1.2.1"
+    "prebuild": "^2.9.0"
   },
   "devDependencies": {
     "mocha": "~1.13.0",
@@ -22,6 +23,7 @@
     "node": ">=0.8"
   },
   "scripts": {
+    "prepublish": "in-publish && node build.js || echo 'Not in npm prepublish.'",
     "install": "prebuild --install",
     "test": "mocha --expose-gc --slow 2000 --timeout 600000"
   },


### PR DESCRIPTION
So, npm's `prepublish` doesn't run as one might expect in the lifecycle process. Namely, it can sometimes run before `npm install`.  For more details about this, you can check out some of the comments made by npm devs on [this issue](https://github.com/npm/npm/issues/3059).

This causes a problem for us because we want to be able to download and build the `libzmq` assets before we run the `install` that occurs only when publishing is done.

Enter the `in-publish` npm package which allows use to use the `in-publish` check in our `prepublish` script to confirm that we are indeed trying to publish the package, in which case we should pull the libzmq assets from the net and build them before moving on to our install step.

On the other end, if someone is installing the `zmq-prebuilt` package the assets won't be downloaded and built.

In order to get these builds working, I'll also need to tinker with how the libraries are pulled in. I'm thinking that `(PRODUCT_DIR)` is not the best way to make a reference to the static build.