### PR TITLE
Fix monitoring test

### DIFF
--- a/test/socket.monitor.js
+++ b/test/socket.monitor.js
@@ -19,7 +19,7 @@ describe('socket.monitor', function() {
       rep.send('world');
     });
 
-    var testedEvents = ['listen', 'accept', 'disconnect', 'close'];
+    var testedEvents = ['listen', 'accept', 'disconnect'];
     testedEvents.forEach(function(e) {
       rep.on(e, function(event_value, event_endpoint_addr) {
         // Test the endpoint addr arg


### PR DESCRIPTION
Monitoring a closed socket was removed in https://github.com/JustinTulloss/zeromq.node/pull/540.

The `should use default interval and numOfEvents` test still times out randomly.