### PR TITLE
Enable Win32 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,4 +24,4 @@ install:
 test_script:
   - node --version
   - npm --version
-  - node windows/smoketest.js
+  - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,20 @@ environment:
 
 platform:
   - x64
+  - Win32
   # - x86 # x86 builds aren't working for now
 
 configuration:
   - release
 
 install:
-  - ps: Install-Product node $env:nodejs_version $env:platform
+  - ps: >-
+        if($env:platform -eq "Win32") {
+          Install-Product node $env:nodejs_version
+        }
+        else {
+          Install-Product node $env:nodejs_version $env:platform
+        }
   - npm install
 
 test_script:


### PR DESCRIPTION
Just messing around with appveyor.

Whats the difference between `x86` and `Win32`?