### PR TITLE
Retry tests on appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,3 @@ sock.on('message', function(topic, message) {
 ## Release
 
 After an `npm` release, push the tag to github and travis will create the prebuilds.
-
-### Shipping Windows binaries
-
-TODO

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm test
+  - appveyor-retry call npm test
 
 deploy_script:
   - IF "%nodejs_version%;%appveyor_repo_tag%"=="4;true" (npm install prebuild -g & prebuild --all -u %gh_token%)


### PR DESCRIPTION
Some tests are timing out randomly. This will retry the testsuite.

Since this is a upstream problem this is the best we can do for now (travis retries as well).