### PR TITLE
Windows prebuilts

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -38,21 +38,7 @@
 #include "nan.h"
 
 #ifdef _WIN32
-# include <delayimp.h>
 # define snprintf _snprintf_s
-  typedef BOOL (WINAPI* SetDllDirectoryFunc)(wchar_t *lpPathName);
-  class SetDllDirectoryCaller {
-   public:
-    explicit SetDllDirectoryCaller() : func_(NULL) { }
-    ~SetDllDirectoryCaller() {
-      if (func_)
-        func_(NULL);
-    }
-    // Sets the SetDllDirectory function pointer to activates this object.
-    void set_func(SetDllDirectoryFunc func) { func_ = func; }
-   private:
-    SetDllDirectoryFunc func_;
-  };
 #endif
 
 #define ZMQ_CAN_DISCONNECT (ZMQ_VERSION_MAJOR == 3 && ZMQ_VERSION_MINOR >= 2) || ZMQ_VERSION_MAJOR > 3
@@ -1586,36 +1572,6 @@ namespace zmq {
 // module
 
 extern "C" NAN_MODULE_INIT(init) {
-#ifdef _MSC_VER
-  // On Windows, inject the windows/lib folder into the DLL search path so that
-  // it will pick up our bundled DLL in case we do not have zmq installed on
-  // this system.
-  HMODULE kernel32_dll = GetModuleHandleW(L"kernel32.dll");
-  SetDllDirectoryCaller caller;
-  SetDllDirectoryFunc set_dll_directory;
-  wchar_t path[MAX_PATH] = L"";
-  wchar_t pathDir[MAX_PATH] = L"";
-  if (kernel32_dll != NULL) {
-    set_dll_directory =
-          reinterpret_cast<SetDllDirectoryFunc>(GetProcAddress(kernel32_dll, "SetDllDirectoryW"));
-    if (set_dll_directory) {
-      GetModuleFileNameW(GetModuleHandleW(L"zmq.node"), path, MAX_PATH - 1);
-      wcsncpy(pathDir, path, wcsrchr(path, '\\') - path);
-      path[0] = '\0';
-      pathDir[wcslen(pathDir)] = '\0';
-# ifdef _WIN64
-      wcscat(pathDir, L"\\..\\..\\windows\\lib\\x64");
-# else
-      wcscat(pathDir, L"\\..\\..\\windows\\lib\\x86");
-# endif
-      _wfullpath(path, pathDir, MAX_PATH);
-      set_dll_directory(path);
-      caller.set_func(set_dll_directory);
-      assert (!FAILED(__HrLoadAllImportsForDll("libzmq-v100-mt-4_0_4.dll")) &&
-          "delayload error");
-    }
-  }
-#endif
   zmq::Initialize(target);
 }
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,39 +3,27 @@
     {
       'target_name': 'zmq',
       'sources': [ 'binding.cc' ],
-      'include_dirs' : [
-        "<!(node -e \"require('nan')\")"
-      ],
+      'include_dirs' : ["<!(node -e \"require('nan')\")"],
+      'cflags!': ['-fno-exceptions'],
+      'cflags_cc!': ['-fno-exceptions'],
       'conditions': [
         ['OS=="win"', {
-          'win_delay_load_hook': 'true',
+          'msbuild_toolset': 'v120',
+          'defines': ['ZMQ_STATIC'],
           'include_dirs': ['windows/include'],
-          'link_settings': {
-            'libraries': [
-              'Delayimp.lib',
-            ],
-            'conditions': [
-              ['target_arch=="ia32"', {
-                'libraries': [
-                  '<(PRODUCT_DIR)/../../windows/lib/x86/libzmq-v100-mt-4_0_4.lib',
-                ]
-              },{
-                'libraries': [
-                  '<(PRODUCT_DIR)/../../windows/lib/x64/libzmq-v100-mt-4_0_4.lib',
-                ]
-              }]
-            ],
-          },
-          'msvs_settings': {
-            'VCLinkerTool': {
-              'DelayLoadDLLs': ['libzmq-v100-mt-4_0_4.dll']
-            }
-          },
-        }, {
-          'libraries': [ '<(PRODUCT_DIR)/../../zmq/lib/libzmq.a' ],
-          'include_dirs': [ '<(PRODUCT_DIR)/../../zmq/include' ],
-          'cflags!': ['-fno-exceptions'],
-          'cflags_cc!': ['-fno-exceptions'],
+          'conditions': [
+            ['target_arch=="ia32"', {
+              'libraries': [
+                '<(PRODUCT_DIR)/../../windows/lib/Win32/libzmq',
+                'ws2_32.lib',
+              ]
+            },{
+              'libraries': [
+                '<(PRODUCT_DIR)/../../windows/lib/x64/libzmq',
+                'ws2_32.lib',
+              ]
+            }]
+          ],
         }],
         ['OS=="mac" or OS=="solaris"', {
           'xcode_settings': {
@@ -43,11 +31,13 @@
             'MACOSX_DEPLOYMENT_TARGET': '10.6',
           },
           'libraries': [ '<(PRODUCT_DIR)/../../zmq/lib/libzmq.a' ],
+          'include_dirs': [ '<(PRODUCT_DIR)/../../zmq/include' ],
         }],
         ['OS=="openbsd" or OS=="freebsd"', {
         }],
         ['OS=="linux"', {
           'libraries': [ '<(PRODUCT_DIR)/../../zmq/lib/libzmq.a' ],
+          'include_dirs': [ '<(PRODUCT_DIR)/../../zmq/include' ],
         }],
       ]
     }

--- a/windows/include/zmq_utils.h
+++ b/windows/include/zmq_utils.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2007-2013 Contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 
@@ -17,89 +17,4 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __ZMQ_UTILS_H_INCLUDED__
-#define __ZMQ_UTILS_H_INCLUDED__
-
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-
-/*  Define integer types needed for event interface                          */
-#if defined ZMQ_HAVE_SOLARIS || defined ZMQ_HAVE_OPENVMS
-#   include <inttypes.h>
-#elif defined _MSC_VER && _MSC_VER < 1600
-#   ifndef int32_t
-typedef __int32 int32_t;
-#   endif
-#   ifndef uint16_t
-typedef unsigned __int16 uint16_t;
-#   endif
-#else
-#   include <stdint.h>
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/*  Handle DSO symbol visibility                                             */
-#if defined _WIN32
-#   if defined ZMQ_STATIC
-#       define ZMQ_EXPORT
-#   elif defined DLL_EXPORT
-#       define ZMQ_EXPORT __declspec(dllexport)
-#   else
-#       define ZMQ_EXPORT __declspec(dllimport)
-#   endif
-#else
-#   if defined __SUNPRO_C  || defined __SUNPRO_CC
-#       define ZMQ_EXPORT __global
-#   elif (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
-#       define ZMQ_EXPORT __attribute__ ((visibility("default")))
-#   else
-#       define ZMQ_EXPORT
-#   endif
-#endif
-
-/* These functions are documented by man pages                                */
-
-/* Encode data with Z85 encoding. Returns encoded data                        */
-ZMQ_EXPORT char *zmq_z85_encode (char *dest, uint8_t *data, size_t size);
-
-/* Decode data with Z85 encoding. Returns decoded data                        */
-ZMQ_EXPORT uint8_t *zmq_z85_decode (uint8_t *dest, char *string);
-
-/* Generate z85-encoded public and private keypair with libsodium.            */
-/* Returns 0 on success.                                                      */
-ZMQ_EXPORT int zmq_curve_keypair (char *z85_public_key, char *z85_secret_key);
-
-typedef void (zmq_thread_fn) (void*);
-
-/*  These functions are not documented by man pages                           */
-
-/*  Helper functions are used by perf tests so that they don't have to care   */
-/*  about minutiae of time-related functions on different OS platforms.       */
-
-/*  Starts the stopwatch. Returns the handle to the watch.                    */
-ZMQ_EXPORT void *zmq_stopwatch_start (void);
-
-/*  Stops the stopwatch. Returns the number of microseconds elapsed since     */
-/*  the stopwatch was started.                                                */
-ZMQ_EXPORT unsigned long zmq_stopwatch_stop (void *watch_);
-
-/*  Sleeps for specified number of seconds.                                   */
-ZMQ_EXPORT void zmq_sleep (int seconds_);
-
-/* Start a thread. Returns a handle to the thread.                            */
-ZMQ_EXPORT void *zmq_threadstart (zmq_thread_fn* func, void* arg);
-
-/* Wait for thread to complete then free up resources.                        */
-ZMQ_EXPORT void zmq_threadclose (void* thread);
-
-#undef ZMQ_EXPORT
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif
+/*  This file is deprecated, and all its functionality provided by zmq.h     */

--- a/windows/lib/Win32/libzmq.lib
+++ b/windows/lib/Win32/libzmq.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64de1e5299d2922b3a21088119a3ba71fb909c9566db135255cffbfe1bf02867
+size 14136030

--- a/windows/lib/x64/libzmq-v100-mt-4_0_4.dll
+++ b/windows/lib/x64/libzmq-v100-mt-4_0_4.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d0d94e343a07b8ba35f5aae5426697b3c2dfdbdd43581e2a13d1faf7023f696
-size 551936

--- a/windows/lib/x64/libzmq-v100-mt-4_0_4.lib
+++ b/windows/lib/x64/libzmq-v100-mt-4_0_4.lib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae2617b7377673606a761ce7e8522e84e78dbb32f0966777298df0603fede5af
-size 12604

--- a/windows/lib/x64/libzmq.lib
+++ b/windows/lib/x64/libzmq.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a455a6de001c82de8040164d93d602a2e197f83f197bc19c16e1681994352cf
+size 16320116

--- a/windows/lib/x86/libzmq-v100-mt-4_0_4.dll
+++ b/windows/lib/x86/libzmq-v100-mt-4_0_4.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ff43b5053933c8f19afc985da3831bbf19af370893c18917feecdb833f415d1
-size 472576

--- a/windows/lib/x86/libzmq-v100-mt-4_0_4.lib
+++ b/windows/lib/x86/libzmq-v100-mt-4_0_4.lib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:704240095ee6fc8cf2863802feff6bb18d91232bc1dd4c984f26996a783e662a
-size 12836


### PR DESCRIPTION
I added a static compiled version of zmq `v4.1.5`. It is linked (statically) in the `.gyp` file. I went ahead and also removed the DLL stuff inside the `bindings.cc` file.

The prebuilts will have a size of approx. 230 kB.
So this time I'm quite confident that the'll work though I didn't know how to test this without a release.