### PR TITLE
Use default Travis OS X image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ os:
   - linux
   - osx
 
-osx_image: xcode7.2
-
 env:
   matrix:
     - NODE_VERSION="6"


### PR DESCRIPTION
Travis CI will stop maintaining this image at the end of the month: https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/