### PR TITLE
Travis: Fix docs and remove unnecessary script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,6 @@ install:
 script: if [[ -z "$ELECTRON" ]]; then travis_retry npm run coverage; else travis_retry npm run test:electron; fi
 
 after_success:
-  - 'if [[ $DEPLOY == true && $TRAVIS_OS_NAME == linux]]; then bash <(curl -s https://codecov.io/bash); fi'
-
-after_sucess:
   - bash ./scripts/publish_docs.sh
 
 deploy:


### PR DESCRIPTION
It seems we don't need the `after_success` script for codecov. to work.