### PR TITLE
Add support for Node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script: if [[ -z "$ELECTRON" ]]; then travis_retry npm run coverage; else travis
 
 after_success:
   - bash ./scripts/publish_docs.sh
+  - 'if [[ $DEPLOY == true && $TRAVIS_OS_NAME == linux ]]; then bash <(curl -s https://codecov.io/bash); fi'
 
 deploy:
   provider: script

--- a/binding.gyp
+++ b/binding.gyp
@@ -21,7 +21,7 @@
           'install_zmq': '<!(./build_libzmq.sh 2>&1 > zmq-build.log)',
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-            'MACOSX_DEPLOYMENT_TARGET': '10.6',
+            'MACOSX_DEPLOYMENT_TARGET': '10.7',
           },
           'libraries': [ '<(PRODUCT_DIR)/../../zmq/lib/libzmq.a' ],
           'include_dirs': [ '<(PRODUCT_DIR)/../../zmq/include' ],

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ coverage:
     status:
         patch:
             default:
-                target: auto
+                target: '30'
         project:
             default:
                 target: auto

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "prebuild": "^4.2.2"
   },
   "devDependencies": {
-    "codecov": "^1.0.1",
     "electron-mocha": "^3.1.1",
     "jsdoc": "^3.4.2",
     "mocha": "^3.1.0",
@@ -30,7 +29,7 @@
     "test": "mocha --expose-gc --slow 300",
     "test:electron": "electron-mocha --slow 300",
     "precoverage": "nyc npm run test",
-    "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
+    "coverage": "nyc report --reporter=text-lcov > coverage/lcov.info"
   },
   "keywords": [
     "zeromq",


### PR DESCRIPTION
- Use codecov bash instead of codecov-node
- Bump OS X deployment target to 10.7, otherwise npm throws:
```
CXX(target) Release/obj.target/zmq/binding.o
clang: error: invalid deployment target for -stdlib=libc++ (requires OS X 10.7 or later)
```
